### PR TITLE
Interpolation

### DIFF
--- a/app/frequencyVisualisation/scripts/frequencyVisualisation.xml.template
+++ b/app/frequencyVisualisation/scripts/frequencyVisualisation.xml.template
@@ -12,6 +12,12 @@
 
   <module>
       <name> frequencyVisualisation </name>
+      <parameters> --name /lowResolutionAudioVisualiser </parameters>
+      <node> icub </node>
+  </module>
+
+  <module>
+      <name> frequencyVisualisation </name>
       <parameters> --name /gammatoneVisualiser </parameters>
       <node> icub </node>
   </module>
@@ -75,14 +81,18 @@
       <parameters> --name /bayesProbabilityPowerAngleVisualiser --gain 100 </parameters>
       <node> icub </node>
   </module>
-  
-
 
 
 
   <module>
       <name> yarpview </name>
       <parameters> --x 100 --y 100 --h 320 --w 240 --r 33 --name /audioMapView </parameters>
+      <node> icub </node>
+  </module>
+
+  <module>
+      <name> yarpview </name>
+      <parameters> --x 100 --y 600 --h 320 --w 240 --r 33 --name /lowResolutionAudioView </parameters>
       <node> icub </node>
   </module>
 
@@ -164,6 +174,12 @@
   </connection> 
 
   <connection>
+      <from> /iCubAudioAttention/LowResolutionAudioMap:o </from>
+      <to>   /lowResolutionAudioVisualiser/map:i         </to>
+      <protocol> tcp </protocol>
+  </connection> 
+
+  <connection>
       <from> /iCubAudioAttention/GammaToneFilteredAudio:o </from>
       <to>   /gammatoneVisualiser/map:i                   </to>
       <protocol> tcp </protocol>
@@ -236,6 +252,12 @@
   <connection>
       <from> /audioMapVisualiser/img:o </from>
       <to>   /audioMapView             </to>
+      <protocol> tcp </protocol>
+  </connection>
+
+  <connection>
+      <from> /lowResolutionAudioVisualiser/img:o </from>
+      <to>   /lowResolutionAudioView             </to>
       <protocol> tcp </protocol>
   </connection>
 

--- a/app/icubAudioAttention/conf/audioConfig.ini
+++ b/app/icubAudioAttention/conf/audioConfig.ini
@@ -1,5 +1,6 @@
 [sampling]
-C                    336.628
+#C                    336.628
+C                    343.36
 nMics                2
 micDistance          0.145
 frameSamples         4096

--- a/app/icubAudioAttention/conf/audioConfig.ini
+++ b/app/icubAudioAttention/conf/audioConfig.ini
@@ -1,23 +1,24 @@
 [sampling]
-C 338
-nMics 2
-micDistance  0.145
-frameSamples 4096
-samplingRate 48000
+C                    336.628
+nMics                2
+micDistance          0.145
+frameSamples         4096
+samplingRate         48000
 
 [preprocessing]
-nBands 128
-lowCf  300
-highCf 2000
-interpolateNSamples 180
+nBands               128
+lowCf                300
+highCf               2000
+interpolateNSamples  180
+radialRes_degrees    1
 
 [bayesian]
-shortBufferSize  2
-mediumBufferSize 6 
-longBufferSize   50
+shortBufferSize      2
+mediumBufferSize     6 
+longBufferSize       50
 
 [powermap]
-bufferSize 20
+bufferSize           20
 
 [robotspec]
-panAngle 2
+panAngle             2

--- a/src/audioBayesianMap/include/audioBayesianRatethread.h
+++ b/src/audioBayesianMap/include/audioBayesianRatethread.h
@@ -46,6 +46,7 @@
 #define THRATE 80 //ms
 inline int    myModed(int a, int b) { return  a >= 0 ? a % b : (a % b) + b; }
 inline double myABS  (double a)     { return  a >= 0 ? a : ((a) * -1);      }
+inline int    myRound(double a)     { return  a - (int)a >= 0.5000 ? (int)a+1 : (int)a; }
 
 class AudioBayesianRatethread : public yarp::os::RateThread {
 

--- a/src/audioBayesianMap/src/audioBayesianRatethread.cc
+++ b/src/audioBayesianMap/src/audioBayesianRatethread.cc
@@ -282,12 +282,14 @@ void AudioBayesianRatethread::calcOffset() {
 	//to do:  redesign this to make use of the SpatialSound class which contains
 	//information about altitude and azimuth so that yarpBayesianMap never needs
 	//to get the position of the head directly from the robot
+	offset = 0.0;
 	if (headAngleInPort->getInputCount()) {
 		headAngleBottle = headAngleInPort->read(true);   //blocking reading for synchr with the input
 		offset = headAngleBottle->get(panAngle).asDouble();
-        //offset += 270;
-		offset += 180;
+        
 	}
+	//offset += 270.0;
+	offset += 180.0;
     // Pushes the current offset into a buffer which
     // is needed to remove "old" audio maps
     bufferedOffSet.push(offset);

--- a/src/audioBayesianMap/src/audioBayesianRatethread.cc
+++ b/src/audioBayesianMap/src/audioBayesianRatethread.cc
@@ -274,12 +274,6 @@ void AudioBayesianRatethread::normalizeProbabilityMap(std::vector <std::vector <
 			probabilityMap[i][j] /= sum;
 		}
 	}
-
-	//--debug.
-	for (int i = 0; i < interpolateNSamples * 2; i++) {
-		if (i % 6) std::cout << std::endl;
-		std::cout << probabilityMap[34][i] << " ";
-	} std::cout << std::endl << std::endl;
 }
 
 

--- a/src/audioBayesianMap/src/audioBayesianRatethread.cc
+++ b/src/audioBayesianMap/src/audioBayesianRatethread.cc
@@ -274,6 +274,12 @@ void AudioBayesianRatethread::normalizeProbabilityMap(std::vector <std::vector <
 			probabilityMap[i][j] /= sum;
 		}
 	}
+
+	//--debug.
+	for (int i = 0; i < interpolateNSamples * 2; i++) {
+		if (i % 6) std::cout << std::endl;
+		std::cout << probabilityMap[34][i] << " ";
+	} std::cout << std::endl << std::endl;
 }
 
 

--- a/src/audioBayesianMap/src/audioBayesianRatethread.cc
+++ b/src/audioBayesianMap/src/audioBayesianRatethread.cc
@@ -285,7 +285,8 @@ void AudioBayesianRatethread::calcOffset() {
 	if (headAngleInPort->getInputCount()) {
 		headAngleBottle = headAngleInPort->read(true);   //blocking reading for synchr with the input
 		offset = headAngleBottle->get(panAngle).asDouble();
-        offset += 270;
+        //offset += 270;
+		offset += 180;
 	}
     // Pushes the current offset into a buffer which
     // is needed to remove "old" audio maps

--- a/src/audioBayesianMap/src/audioBayesianRatethread.cc
+++ b/src/audioBayesianMap/src/audioBayesianRatethread.cc
@@ -289,7 +289,10 @@ void AudioBayesianRatethread::calcOffset() {
         
 	}
 	//offset += 270.0;
-	offset += 180.0;
+	//offset += 180.0;
+	offset += 360.0; // center of ego map is now 180 degrees.
+
+
     // Pushes the current offset into a buffer which
     // is needed to remove "old" audio maps
     bufferedOffSet.push(offset);
@@ -446,7 +449,7 @@ void AudioBayesianRatethread::addMap(std::vector <std::vector <double> > &probab
 	// Bayesian map corresponding to the input probabilityMap
 	for (int i = 0; i <  nBands; i++) {
 		for (int j = 0; j < interpolateNSamples * 2; j++) {
-			int o =  myModed((j + (int)offset), interpolateNSamples * 2);
+			int o =  myModed((j + myRound(offset)), interpolateNSamples * 2);
 			probabilityMap[i][j] *= inputCurrentAudioMap[i][o];
 		}
 	}
@@ -465,7 +468,7 @@ void AudioBayesianRatethread::removeMap(std::vector <std::vector <double> > &pro
 	// the Bayesian map corresponding to the input probabilityMap
 	for (int i = 0; i <  nBands; i++) {
 		for (int j = 0; j < interpolateNSamples * 2; j++) {
-			int o =  myModed((j + (int)bufferedOffSet.front()), interpolateNSamples * 2);
+			int o =  myModed((j + myRound(bufferedOffSet.front())), interpolateNSamples * 2);
 			probabilityMap[i][j] /= inputCurrentAudioMap[i][o];
 		}
 	}
@@ -478,7 +481,7 @@ void AudioBayesianRatethread::removeNoise(std::vector <std::vector <double>> &pr
 	// corresponding to the input probabilityMap
 	for (int i = 0; i <  nBands; i++) {
 		for (int j = 0; j < interpolateNSamples * 2; j++) {
-			int o =  myModed((j + (int)offset), interpolateNSamples * 2);
+			int o =  myModed((j + myRound(offset)), interpolateNSamples * 2);
 			probabilityMap[i][j] /= noiseMap[i][o];
 		}
 	}

--- a/src/audioPreprocessing/include/audioPreprocesserRatethread.h
+++ b/src/audioPreprocessing/include/audioPreprocesserRatethread.h
@@ -329,7 +329,7 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
      *
      *  @return the corresponding y value of the asked x
      */
-    inline double linearApproximation(int x, int x1, double y1, int x2, double y2);
+    inline double linearApproximation(double x, double x1, double y1, double x2, double y2);
 
 
     /**

--- a/src/audioPreprocessing/include/audioPreprocesserRatethread.h
+++ b/src/audioPreprocessing/include/audioPreprocesserRatethread.h
@@ -74,6 +74,7 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
 	yarp::os::Port *outBeamFormedAudioPort;
     //yarp::os::BufferedPort<yarp::sig::Matrix> *outBeamFormedPowerAudioPort;
     yarp::os::Port *outBeamFormedPowerAudioPort;
+    yarp::os::BufferedPort<yarp::sig::Matrix> *outLowResolutionAudioMapPort;
 	yarp::os::Port *outAudioMapEgoPort;
 
 	yarp::os::Stamp ts;
@@ -260,6 +261,8 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
      *  The audio map is stored in outAudioMap and sent though port audioMapPort.
      */
      void sendAudioMap();
+
+    void sendLowResolutionAudioMap();
 
 
     /**

--- a/src/audioPreprocessing/include/audioPreprocesserRatethread.h
+++ b/src/audioPreprocessing/include/audioPreprocesserRatethread.h
@@ -103,6 +103,8 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
     yarp::sig::Vector spaceAngles;
     yarp::sig::Vector micAngles;
 
+    yarp::sig::Matrix lowResolutionAudioMap;
+
 
 	//
 	// processing objects
@@ -309,6 +311,9 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
      *  @param beamFormedPower : power of reduced beamformed audio across each band.
      */
     void sendBeamFormedPowerAudio(const std::vector< double > &beamFormedPower);
+
+
+    void setLowResolutionMap();
 
 
     /**

--- a/src/audioPreprocessing/include/audioPreprocesserRatethread.h
+++ b/src/audioPreprocessing/include/audioPreprocesserRatethread.h
@@ -27,6 +27,7 @@
 #define _AUDIO_PREPROCESSER_RATETHREAD_H_
 
 #include <iostream>
+//#include <cmath>
 
 #include <yarp/dev/all.h>
 
@@ -41,7 +42,8 @@
 #include "gammatoneFilter.h"
 #include "beamFormer.h"
 
-const float normDivid = pow(2,15); 
+const float  normDivid = pow(2,15);
+const double _pi       = 2 * acos(0.0); 
 
 //const float normDivid = pow(2,23);  // Number that is used to convert the integer number received
                                     // as the audio signal and convert it to a double audio signal
@@ -95,11 +97,18 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
 	float *rawAudio;
 
 
+
+    //----------------------------------
+    
+    yarp::sig::Vector spaceAngles;
+    yarp::sig::Vector micAngles;
+
+
 	//
 	// processing objects
 	//
 	GammatoneFilter *gammatoneAudioFilter;
-	BeamFormer *beamForm;
+	BeamFormer      *beamForm;
 
 
     int lastframe;
@@ -122,9 +131,13 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
     int    lowCf;
     int    highCf;
     int    interpolateNSamples;
+    int    radialRes_degrees;
 
     int    nBeamsPerHemi;
     int    nBeams;
+    int    nMicAngles;
+    double radialRes_radians;
+    int    nSpaceAngles;
     
     
     

--- a/src/audioPreprocessing/include/audioPreprocesserRatethread.h
+++ b/src/audioPreprocessing/include/audioPreprocesserRatethread.h
@@ -317,7 +317,7 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
 
 
     /**
-     *  linerApproximation
+     *  linearApproximation
      *
      *  Helper function used by linerInterp to do liner interpolation between points (x1,y1) and (x2,y2).
      *
@@ -329,17 +329,17 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
      *
      *  @return the corresponding y value of the asked x
      */
-    inline double linerApproximation(int x, int x1, double y1, int x2, double y2);
+    inline double linearApproximation(int x, int x1, double y1, int x2, double y2);
 
 
     /**
-     *  linerInterpolate
+     *  linearInterpolate
      *
      *  Taking the Audio data that is found in reducedBeamFormedAudioVector.
      *  Creates an interpolation of the data corresponding to the interpolateNSamples that was specified in the xml.
      *  The data of this function will be saved in highResolutionAudioMap.
      */
-    void linerInterpolate();
+    void linearInterpolate();
 
 
     /**

--- a/src/audioPreprocessing/include/audioPreprocesserRatethread.h
+++ b/src/audioPreprocessing/include/audioPreprocesserRatethread.h
@@ -102,31 +102,35 @@ class AudioPreprocesserRatethread : public yarp::os::RateThread {
 	BeamFormer *beamForm;
 
 
-    //
-    // derived variables
-    //
     int lastframe;
-    int totalBeams;
     int longBufferSize;
-    int nBeamsPerHemi;
+    
 
     double startTime;
     double stopTime;
 
 
-    //
-    // variables from resource finder
-    //
-    int C;
-    int frameSamples;
-    int highCf;
-    int interpolateNSamples;
-    int lowCf;
-    int nBands;
-    int nMics;
-    int samplingRate;
-
+    //--
+    //-- Variables Set on Init.
+    //--
+    double C;
+    int    nMics;
     double micDistance;
+    int    frameSamples;
+    int    samplingRate;
+    int    nBands;
+    int    lowCf;
+    int    highCf;
+    int    interpolateNSamples;
+
+    int    nBeamsPerHemi;
+    int    nBeams;
+    
+    
+    
+    
+
+    
 
 
  public:

--- a/src/audioPreprocessing/src/audioPreprocesserRatethread.cpp
+++ b/src/audioPreprocessing/src/audioPreprocesserRatethread.cpp
@@ -328,7 +328,7 @@ void AudioPreprocesserRatethread::run() {
 
 	// do an interpolate on the lowResolutionAudioMap
 	// to produce a highResolutionAudioMap
-	linerInterpolate();
+	linearInterpolate();
     //splineInterpolate();
 
 	if (outAudioMapEgoPort->getOutputCount()) {
@@ -591,8 +591,21 @@ void AudioPreprocesserRatethread::setLowResolutionMap() {
 
 	for (int band = 0; band < nBands; band++) {
 
+		//int current_beam = 0;
+		//for (int beam = nBeams-nBeamsPerHemi-1; beam < nBeams-1; beam++) {
+		//	lowResolutionAudioMap[band][current_beam++] = reducedBeamFormedAudioVector[beam][band];
+		//}
+//
+		//for (int beam = 0; beam < nBeams; beam++) {
+		//	lowResolutionAudioMap[band][current_beam++] = reducedBeamFormedAudioVector[beam][band];
+		//}
+//
+		//for (int beam = 1; beam < nBeams-nBeamsPerHemi-1; beam++) {
+		//	lowResolutionAudioMap[band][current_beam++] = reducedBeamFormedAudioVector[beam][band];
+		//}
+
 		int current_beam = 0;
-		for (int beam = nBeams-nBeamsPerHemi-1; beam < nBeams-1; beam++) {
+		for (int beam = nBeams-nBeamsPerHemi-1; beam > 0; beam--) {
 			lowResolutionAudioMap[band][current_beam++] = reducedBeamFormedAudioVector[beam][band];
 		}
 
@@ -600,20 +613,27 @@ void AudioPreprocesserRatethread::setLowResolutionMap() {
 			lowResolutionAudioMap[band][current_beam++] = reducedBeamFormedAudioVector[beam][band];
 		}
 
-		for (int beam = 1; beam < nBeams-nBeamsPerHemi-1; beam++) {
+		for (int beam = nBeams-2; beam > nBeams-nBeamsPerHemi-1; beam--) {
 			lowResolutionAudioMap[band][current_beam++] = reducedBeamFormedAudioVector[beam][band];
 		}
 	}
+
+
+	//--debug.
+	for (int i = 0; i < nMicAngles; i++) {
+		if (i % 6) std::cout << std::endl;
+		std::cout << lowResolutionAudioMap[34][i] << " ";
+	} std::cout << std::endl << std::endl;
 }
 
 
 
-inline double AudioPreprocesserRatethread::linerApproximation(int x, int x1, double y1, int x2, double y2) {
+inline double AudioPreprocesserRatethread::linearApproximation(int x, int x1, double y1, int x2, double y2) {
 	return y1 + ((y2 - y1) * (x - x1)) / (x2 - x1);
 }
 
 
-void AudioPreprocesserRatethread::linerInterpolate() {
+void AudioPreprocesserRatethread::linearInterpolate() {
 
 	/*  TODO : REMOVE THIS BLOCK.
 
@@ -672,7 +692,7 @@ void AudioPreprocesserRatethread::linerInterpolate() {
 			}
 
 			//-- Interpolate for this position.
-			highResolutionAudioMap[sAngle][band] = linerApproximation(
+			highResolutionAudioMap[sAngle][band] = linearApproximation(
 				spaceAngles[sAngle],
 				micAngles[mAngle-1],
 				lowResolutionAudioMap[band][mAngle-1],

--- a/src/audioPreprocessing/src/audioPreprocesserRatethread.cpp
+++ b/src/audioPreprocessing/src/audioPreprocesserRatethread.cpp
@@ -144,6 +144,66 @@ bool AudioPreprocesserRatethread::threadInit() {
 	// prepare other memory structures
 	rawAudio = new float[(frameSamples * nMics)];
 
+	//--
+	//-- Find the Spacing of the beams, for proper interpolation.
+	//--
+
+	//-- Generate the angles at which each beam is pointed.
+	yarp::sig::Vector angles(nBeams);
+	for (int beam = 0; beam < nBeams; beam++) {
+		angles[beam] = (1.0 / micDistance) * (-nBeamsPerHemi + beam) * (C / samplingRate);
+		angles[beam] = (angles[beam] <= -1.0) ? -1.0 : angles[beam];  //-- Make sure we are in 
+		angles[beam] = (angles[beam] >=  1.0) ?  1.0 : angles[beam];  //-- range to avoid NAN.
+		angles[beam] = asin(angles[beam]);
+	}
+
+
+	//-- Generate a lineaer distribution of the angles in space.
+	double linspace_step = ((_pi - radialRes_radians) - (-_pi)) / (nSpaceAngles - 1.0);
+	double current_step  = -_pi;
+
+	spaceAngles.resize(nSpaceAngles, 0.0);
+	
+	for (int angle = 0; angle < nSpaceAngles; angle++) {
+		spaceAngles[angle] = current_step;
+		current_step += linspace_step;
+	}
+
+
+	//-- Generate the non-linear distribution of where all beams are pointed.
+	int current_mic_pos = 0;
+
+	micAngles.resize(nMicAngles, 0.0);
+
+	//-- First section is the last half of angles + pi.
+	for (int beam = nBeams-nBeamsPerHemi-1; beam < nBeams-1; beam++) {
+		micAngles[current_mic_pos++] = angles[beam] + _pi;
+	}
+
+	//-- Second section is just the entire angles.
+	for (int beam = 0; beam < nBeams; beam++) {
+		micAngles[current_mic_pos++] = angles[beam];
+	}
+
+	//-- Third section is the first half of angles + pi.
+	for (int beam = 1; beam < nBeams-nBeamsPerHemi-1; beam++) {
+		micAngles[current_mic_pos++] = angles[beam] + _pi;
+	}
+	
+	//-- Unwrap the micAngles by changing deltas between values to 2*pi complement.
+	for (int angle = 1; angle < nMicAngles; angle++) {		
+		double delta = micAngles[angle] - micAngles[angle-1];
+		delta = (delta > _pi) ? delta - 2 * _pi : ( (delta < -_pi) ? delta + 2 * _pi : delta );
+		micAngles[angle] = micAngles[angle-1] + delta;
+	}
+
+	//-- Normalize all microphone positions to +/- pi.
+	for (int angle = 0; angle < nMicAngles; angle++) {
+		micAngles[angle] -= (2 * _pi);
+	}
+
+
+
 	// initialize a two dimentianl vector that
 	// is 2 * interpolateNSamples x nBands
 	for (int i = 0; i < interpolateNSamples * 2; i++) {
@@ -311,35 +371,41 @@ void AudioPreprocesserRatethread::loadFile(yarp::os::ResourceFinder &rf) {
 	// import all relevant data fron the .ini file
 	yInfo("Loading Configuration File.");
 	try {
-		C            = rf.findGroup("sampling").check("C",            Value(338),   "C speed of sound (int)").asInt();
-		nMics        = rf.findGroup("sampling").check("nMics",        Value(2),     "number mics (int)").asInt();
-		micDistance  = rf.findGroup("sampling").check("micDistance",  Value(0.145), "micDistance (double)").asDouble();
-		frameSamples = rf.findGroup("sampling").check("frameSamples", Value(4096),  "frame samples (int)").asInt();
-		samplingRate = rf.findGroup("sampling").check("samplingRate", Value(48000), "sampling rate of mics (int)").asInt();
+		C            = rf.findGroup("sampling").check("C",            Value(336.628), "C speed of sound (double)").asDouble();
+		nMics        = rf.findGroup("sampling").check("nMics",        Value(2),       "number mics (int)").asInt();
+		micDistance  = rf.findGroup("sampling").check("micDistance",  Value(0.145),   "micDistance (double)").asDouble();
+		frameSamples = rf.findGroup("sampling").check("frameSamples", Value(4096),    "frame samples (int)").asInt();
+		samplingRate = rf.findGroup("sampling").check("samplingRate", Value(48000),   "sampling rate of mics (int)").asInt();
 		
 		nBands              = rf.findGroup("preprocessing").check("nBands",              Value(128),  "numberBands (int)").asInt();
 		lowCf               = rf.findGroup("preprocessing").check("lowCf",               Value(1000), "lowest center frequency (int)").asInt();
 		highCf              = rf.findGroup("preprocessing").check("highCf",              Value(3000), "highest center frequency (int)").asInt();
 		interpolateNSamples = rf.findGroup("preprocessing").check("interpolateNSamples", Value(180),  "interpellate N samples (int)").asInt();
-		
-		//nBeamsPerHemi  = (int)((micDistance / C) * samplingRate) - 1;
-		//nBeams = nBeamsPerHemi * 2 + 1;
+		radialRes_degrees   = rf.findGroup("preprocessing").check("radialRes_degrees",   Value(1),    "Degrees Per Possible Head Direction (int)").asInt();
+
 
 		//-- Take the ceiling of of (D/C)/Rate.
 		//--   ceiling = (x + y - 1) / y
-		nBeamsPerHemi = ((micDistance * samplingRate) + C - 1.0) / C;
-		nBeams = 2 * nBeamsPerHemi + 1;
+		nBeamsPerHemi     = ((micDistance * samplingRate) + C - 1.0) / C;
+		nBeams            = 2 * nBeamsPerHemi + 1;
+	    nMicAngles        = nBeams * 2 - 2;
+		radialRes_radians = _pi / 180.0 * radialRes_degrees;
+		nSpaceAngles      = 360 / radialRes_degrees;
 
-		// print information from rf to the console
-		yInfo("\t nMics                        = %d", nMics);
-		yInfo("\t micDistance                  = %f", micDistance);
-		yInfo("\t frameSamples                 = %d", frameSamples);
-		yInfo("\t nBands                       = %d", nBands);
-    	yInfo("\t low Cutting frequency        = %d",lowCf);
-    	yInfo("\t high Cutting frequency       = %d",highCf);
-		yInfo("\t Num Beams Per Hemifield   %d = %f / %d * %d", nBeamsPerHemi, micDistance, C, samplingRate);
-		yInfo("\t Total Beams                  = %d",nBeams);
-		yInfo("\t interpolateNSamples          = %d", interpolateNSamples );
+		//-- Print information from rf to the console.
+		yInfo("\t nMics                           = %d", nMics);
+		yInfo("\t micDistance                     = %f", micDistance);
+		yInfo("\t frameSamples                    = %d", frameSamples);
+		yInfo("\t nBands                          = %d", nBands);
+    	yInfo("\t low Cutting frequency           = %d", lowCf);
+    	yInfo("\t high Cutting frequency          = %d", highCf);
+		yInfo("\t Num Beams Per Hemifield      %d = ceil(%f / %f * %d)", nBeamsPerHemi, micDistance, C, samplingRate);
+		yInfo("\t Total Num Beams                 = %d", nBeams);
+		yInfo("\t nMicAngles                      = %d", nMicAngles);
+		yInfo("\t interpolateNSamples             = %d", interpolateNSamples );
+		yInfo("\t Radial Resolution (Degrees)     = %d", radialRes_degrees);
+		yInfo("\t Radial Resolution (Radians)     = %f", radialRes_radians);
+		yInfo("\t Num Space Angles                = %d", nSpaceAngles);
 	}
 
 	catch (int a) {
@@ -514,11 +580,12 @@ void AudioPreprocesserRatethread::sendAudioMap() {
 
 inline double AudioPreprocesserRatethread::linerApproximation(int x, int x1, double y1, int x2, double y2) {
 	return y1 + ((y2 - y1) * (x - x1)) / (x2 - x1);
-	//return y2;
 }
 
 
 void AudioPreprocesserRatethread::linerInterpolate() {
+
+	/*  TODO : REMOVE THIS BLOCK.
 
 	double offset = (interpolateNSamples / (double)nBeams);
 
@@ -559,6 +626,29 @@ void AudioPreprocesserRatethread::linerInterpolate() {
 																reducedBeamFormedAudioVector[k][i],		// y1
 																curroffset,								// x2
 																reducedBeamFormedAudioVector[k-1][i]);	// y2
+		}
+	}
+	*/ 
+
+	for (int band = 0; band < nBands; band++) {
+		
+		int mAngle = 1;
+		for (int sAngle = 0; sAngle < nSpaceAngles; sAngle++) {
+			
+			//-- If the offset angle is smaller than the normal angle, 
+			//-- move to the next offset angle.
+			if (spaceAngles[sAngle] > micAngles[mAngle] && mAngle < nMicAngles-1) {
+				mAngle++;
+			}
+
+			//-- Interpolate for this position.
+			highResolutionAudioMap[sAngle][band] = linerApproximation(
+				spaceAngles[sAngle],
+				micAngles[mAngle-1],
+				reducedBeamFormedAudioVector[mAngle-1][band],
+				micAngles[mAngle],
+				reducedBeamFormedAudioVector[mAngle][band]
+			);
 		}
 	}
 }

--- a/src/audioPreprocessing/src/audioPreprocesserRatethread.cpp
+++ b/src/audioPreprocessing/src/audioPreprocesserRatethread.cpp
@@ -617,18 +617,11 @@ void AudioPreprocesserRatethread::setLowResolutionMap() {
 			lowResolutionAudioMap[band][current_beam++] = reducedBeamFormedAudioVector[beam][band];
 		}
 	}
-
-
-	//--debug.
-	for (int i = 0; i < nMicAngles; i++) {
-		if (i % 6) std::cout << std::endl;
-		std::cout << lowResolutionAudioMap[34][i] << " ";
-	} std::cout << std::endl << std::endl;
 }
 
 
 
-inline double AudioPreprocesserRatethread::linearApproximation(int x, int x1, double y1, int x2, double y2) {
+inline double AudioPreprocesserRatethread::linearApproximation(double x, double x1, double y1, double x2, double y2) {
 	return y1 + ((y2 - y1) * (x - x1)) / (x2 - x1);
 }
 


### PR DESCRIPTION
Merging branch into Master. Changes include:
- linear interpolation over beam angles (changed from linearly spaced angles)
- changed the linear interpolator to take doubles as the x position over ints
- added a port for viewing the pre-interpolated audio map. This view is of the beams in the front and back view (which are non-linearly spaced)
- removed the preprocessor from auto connecting to /sender on launch
- the angle of the head joint now comes from the init file (this will be changed later to get the azimuth angle from ikin gaze control)
- Bayes now offsets by 360 instead of 270. This is done because of the new egocentric audio map is centred at 180 instead of 90 degrees.
